### PR TITLE
Update Log4j to 2.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
 
 


### PR DESCRIPTION
Log4j 1.16 stil has some (although less servere) ways the log4j exploit can be executed.

Since the serverity of the exploit and my intrest in using the plugin I felt a Pull request
would be in order.

Have a nice day!